### PR TITLE
task-5107 merge in pescini prod

### DIFF
--- a/mrp_bom_line_formula_quantity/models/mrp_bom_line.py
+++ b/mrp_bom_line_formula_quantity/models/mrp_bom_line.py
@@ -80,7 +80,13 @@ class MRPBomLine(models.Model):
                 mode="exec",
                 nocopy=True,
             )
-            quantity = values.get("quantity", 0)
+            formula_quantity = values.get("quantity", 0)
+            product_uom_qty = values.get("product_uom_qty", 0)
+            quantity = (
+                formula_quantity * product_uom_qty
+                if formula_quantity and product_uom_qty
+                else 0
+            )
         else:
             quantity = None
         return quantity

--- a/mrp_bom_line_formula_quantity/tests/test_mrp_production.py
+++ b/mrp_bom_line_formula_quantity/tests/test_mrp_production.py
@@ -15,6 +15,7 @@ class TestMRPProduction(TestMrpCommon):
         formula_quantity = 10
         bom = self.bom_1.copy()
         formula_bom_line = first(bom.bom_line_ids)
+        formula_bom_line.product_qty = 1
         formula_bom_line["quantity_formula"] = "quantity = %s" % formula_quantity
         # pre-condition
         self.assertNotEqual(formula_bom_line.product_qty, formula_quantity)
@@ -23,6 +24,7 @@ class TestMRPProduction(TestMrpCommon):
         order = self.env["mrp.production"].create(
             {
                 "bom_id": bom.id,
+                "product_qty": bom.product_qty,
             }
         )
 


### PR DESCRIPTION
[FIX] components quantities not updating
On the production order, when changing the final product quantities to >1, the components quantities did not update correctly.
https://aion-tech.odoo.com/web#id=5107&cids=1&model=project.task&view_type=form